### PR TITLE
ci: gate rules deploy on rules change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,14 @@ jobs:
       - name: Checkout git repository
         uses: actions/checkout@v4
 
+      - name: Detect database rules changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            rules:
+              - 'web/database.rules.json'
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -71,6 +79,10 @@ jobs:
         working-directory: ./web
 
       - name: Deploy database security rules
+        # Only when the rules actually changed — keeps Firebase credentials out
+        # of every routine static deploy. FIREBASE_TOKEN auth here is deprecated
+        # and pending migration to a service account.
+        if: steps.changes.outputs.rules == 'true'
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: npx firebase-tools deploy --only database --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }}


### PR DESCRIPTION
The Deploy workflow runs `firebase-tools deploy --only database` on every push to master. That step authenticates with the deprecated FIREBASE_TOKEN, whose credential has since been invalidated — so the merge of the Firebase migration failed at that step and production was never updated, even though the security rules hadn't changed.

This gates the rules-deploy step on web/database.rules.json actually changing (via dorny/paths-filter). Routine static deploys no longer touch Firebase credentials at all; the rules step only runs when the rules change.

Migrating that step's auth off FIREBASE_TOKEN to a scoped service account is tracked separately.