### PR TITLE
ci: deploy RTDB rules via scoped service account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,12 +80,16 @@ jobs:
 
       - name: Deploy database security rules
         # Only when the rules actually changed — keeps Firebase credentials out
-        # of every routine static deploy. FIREBASE_TOKEN auth here is deprecated
-        # and pending migration to a service account.
+        # of every routine static deploy. Authenticates firebase-tools with a
+        # scoped service-account key (GOOGLE_APPLICATION_CREDENTIALS) rather than
+        # the deprecated FIREBASE_TOKEN.
         if: steps.changes.outputs.rules == 'true'
         env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        run: npx firebase-tools deploy --only database --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+        run: |
+          printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$RUNNER_TEMP/firebase-key.json"
+          export GOOGLE_APPLICATION_CREDENTIALS="$RUNNER_TEMP/firebase-key.json"
+          npx firebase-tools deploy --only database --project ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
         working-directory: ./web
 
       - name: Deploy to Netlify

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: Build & Test
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build-test:


### PR DESCRIPTION
Migrates the Deploy database security rules step in deploy.yml off the deprecated, now-invalidated FIREBASE_TOKEN to a scoped GCP service-account key.

## What changed
- The rules-deploy step now writes the FIREBASE_SERVICE_ACCOUNT secret to a runtime key file and points GOOGLE_APPLICATION_CREDENTIALS at it; firebase-tools authenticates from that automatically.
- Change-gating (if: steps.changes.outputs.rules == 'true', added in #105) is unchanged — routine static deploys skip the step and never touch Firebase credentials. Netlify deploy still runs every push.

## Required secret changes (manual, before a rules-changing deploy)
- Create a least-privilege service account in digital-icebreakers with Firebase Realtime Database Admin (roles/firebasedatabase.admin); generate a JSON key.
- Store the key as GitHub secret FIREBASE_SERVICE_ACCOUNT.
- Delete the old FIREBASE_TOKEN secret.